### PR TITLE
Ip address message duplication fix

### DIFF
--- a/utils/kubesat/validation.py
+++ b/utils/kubesat/validation.py
@@ -195,18 +195,6 @@ class MessageSchemas:
         }
     }
 
-    IP_ADDRESS_MESSAGE = {
-        "name": "ip_address_message",
-        "type": "object",
-        "additionalProperties": True,
-        "required": ["data"],
-        "properties": {
-            "data": {
-                "type": "string"
-            }
-        }
-    }
-
     SEND_DATA_MESSAGE = {
         "name": "send_data_message",
         "type": "object",


### PR DESCRIPTION
This PR addresses issue #8 
Removes the duplicate structure of IP_ADDRESS_MESSAGE in validation.py

Signed-off-by: Jordan Karaze <jordan.karaze@ibm.com>