### PR TITLE
add copyright and license header

### DIFF
--- a/examples/hello_service.py
+++ b/examples/hello_service.py
@@ -1,3 +1,7 @@
+#
+# Copyright (C) 2020 IBM. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
 import asyncio
 import time
 


### PR DESCRIPTION
All source files should have a copyright and license header. My preference is to use the SPDX header style as it is more compact and easily scanable.

Signed-off-by: Christopher Ferris <chrisfer@us.ibm.com>